### PR TITLE
Add dependency installation oneliner for Fedora to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ AUR: [dualsensectl-git](https://aur.archlinux.org/packages/dualsensectl-git/)
 * libhidapi-hidraw
 * libdbus-1
 
+#### Installing dependencies on Fedora
+
+    sudo dnf install gcc hidapi-devel dbus-devel
+
 ### Building
 
-    make && make install
+Install dependencies first (see above), then run:
+
+    make && sudo make install
 
 ### udev rules
 


### PR DESCRIPTION
This should make compiling a bit easier. Tested on a fresh Fedora 37 Docker container.

I've also added `sudo` in front of `make install` as it's needed on most desktop distributions (which don't use a root account).