### PR TITLE
Fix compare_serial to be case insensitive

### DIFF
--- a/main.c
+++ b/main.c
@@ -337,7 +337,7 @@ static bool compare_serial(const char *s, const wchar_t *dev)
         return false;
     }
     for (size_t i = 0; i < len; ++i) {
-        if (s[i] != dev[i]) {
+        if (toupper(s[i]) != toupper(dev[i])) {
             return false;
         }
     }
@@ -1198,7 +1198,7 @@ static void print_help(void)
     printf("\n");
     printf("Options:\n");
     printf("  -l                                       List available devices\n");
-    printf("  -d DEVICE                                Specify which device to use\n");
+    printf("  -d DEVICE_SERIAL_NUMBER                  Specify which device to use with a serial number (format: 00:00:00:00:00:00)\n");
     printf("  -w                                       Wait for shell command to complete (monitor only)\n");
     printf("  -h --help                                Show this help message\n");
     printf("  -v --version                             Show version\n");


### PR DESCRIPTION
compare_serial function was case sensitive and that was a problem because internally the device serial number was handled as lowercase but printed as uppercase.

Additionally I added better help description of -d option